### PR TITLE
Add image name container prop to deployOpenShiftTemplate

### DIFF
--- a/vars/deployOpenShiftTemplate.groovy
+++ b/vars/deployOpenShiftTemplate.groovy
@@ -63,7 +63,8 @@ def call(Map parameters = [:], Closure body) {
             def tag = containerProps.get('tag', 'stable')
             def cmd = containerProps.get('command', 'cat')
             def privileged = containerProps.get('privileged', true)
-            def imageUrl = "${docker_repo_url}/${openshift_namespace}/${containerName}:${tag}"
+            def containerImageName = containerProps.get('image', containerName)
+            def imageUrl = "${docker_repo_url}/${openshift_namespace}/${containerImageName}:${tag}"
 
             containerTemplates << containerTemplate(name: containerName,
                     alwaysPullImage: true,


### PR DESCRIPTION
Add _image_ container property to deployOpenShiftTemplate so we can have containers named differently than their image. This is especially useful if we want to run multiple containers using the same image. The default behaviour stays the same.