### PR TITLE
Add build_number to pipelineMetrics

### DIFF
--- a/vars/pipelineMetrics.groovy
+++ b/vars/pipelineMetrics.groovy
@@ -23,6 +23,7 @@ def call(Map parameters = [:]) {
     }
 
     cimetrics.setMetricTag(env.JOB_NAME, 'build_result', currentBuild.currentResult)
+    cimetrics.setMetricTag(env.JOB_NAME, 'build_number', currentBuild.id)
     cimetrics.setMetricField(env.JOB_NAME, 'build_time', currentBuild.getDuration())
 
     writeToInflux(customDataMap: cimetrics.customDataMap,


### PR DESCRIPTION
- Helpful in case where you want a chart that lists the build_number as a tag.