### PR TITLE
Add option to return stdout from executeInContainer

### DIFF
--- a/vars/executeInContainer.groovy
+++ b/vars/executeInContainer.groovy
@@ -16,6 +16,7 @@ def call(Map parameters) {
     def stageName = parameters.get('stageName', env.STAGE_NAME)
     def loadProps = parameters.get('loadProps', [])
     def credentials = parameters.get('credentials', [])
+    def returnStdout = parameters.get('returnStdout', false)
 
     handlePipelineStep {
         withCredentials(credentials) {
@@ -35,7 +36,7 @@ def call(Map parameters) {
             try {
                 withEnv(containerEnv) {
                     container(containerName) {
-                        sh containerScript
+                        sh script: containerScript, returnStdout: returnStdout
                     }
                 }
 


### PR DESCRIPTION
Add option to return standard output from `executeInContainer` shell step.