### PR TITLE
Add ci.pipeline.stage.[running,complete] messages

### DIFF
--- a/resources/msgBusPipelineContent.json
+++ b/resources/msgBusPipelineContent.json
@@ -13,13 +13,6 @@
       "description": "UUID for this pipeline run",
       "required": true
     },
-  "status":
-    {
-      "value": null,
-      "type": "java.lang.String",
-      "description": "Status of the pipeline (overall) values: running, complete, error, aborted, unstable",
-      "required": true
-    },
   "build":
     {
       "value": null,
@@ -33,5 +26,11 @@
       "type": "java.math.BigDecimal",
       "description": "The runtime in seconds of the pipeline",
       "required": false
-    }
+    },
+  "stage": {
+    "value": {},
+    "type": "groovy.lang.Closure",
+    "description": "The stage content Map",
+    "required": true
+  }
 }

--- a/resources/msgBusPipelineMsg.json
+++ b/resources/msgBusPipelineMsg.json
@@ -17,12 +17,6 @@
     "description": "The run content Map",
     "required": true
   },
-  "artifact": {
-    "value": {},
-    "type": "groovy.lang.Closure",
-    "description": "The artifact content Map",
-    "required": true
-  },
   "pipeline": {
     "value": {},
     "type": "groovy.lang.Closure",

--- a/resources/msgBusStageContent.json
+++ b/resources/msgBusStageContent.json
@@ -5,12 +5,6 @@
     "description": "The name of the pipeline stage this message pertains to",
     "required": true
   },
-  "status": {
-    "value": "complete",
-    "type": "java.lang.String",
-    "description": "Values: running, complete",
-    "required": true
-  },
   "runtime":
     {
       "value": 0.0,

--- a/resources/msgBusStageMsg.json
+++ b/resources/msgBusStageMsg.json
@@ -17,22 +17,10 @@
     "description": "The run content Map",
     "required": true
   },
-  "artifact": {
-    "value": {},
-    "type": "groovy.lang.Closure",
-    "description": "The artifact content Map",
-    "required": true
-  },
   "pipeline": {
     "value": {},
     "type": "groovy.lang.Closure",
     "description": "The pipeline content Map",
-    "required": true
-  },
-  "stage": {
-    "value": {},
-    "type": "groovy.lang.Closure",
-    "description": "The stage content Map",
     "required": true
   }
 }

--- a/vars/ciStage.groovy
+++ b/vars/ciStage.groovy
@@ -1,0 +1,63 @@
+/**
+ * requires: following env vars
+ * env.topicPrefix: The prefix of the message topic. Choices include org.fedoraproject.prod.ci and VirtualTopic.eng.ci
+ * env.effortName: Name of the effort or pipeline
+ * env.teamName
+ * env.teamEmail
+ * env.pipelineId: UUID for this pipeline run
+ * optional:
+ * env.teamIRC: team's irc channel
+ * env.pipelineName: For use if the pipeline name differs from the effort name
+ * Example Usage:
+ *
+ *  ciStage('run-stage') {
+ *      runCode()
+ *  }
+ *
+ * @param stageName: Name to give the stage
+ * @param body
+ * @return
+ */
+
+def call(String stageName, Closure body) {
+    // Make sure required env variables are set
+    if (!env.topicPrefix || !env.effortName || !env.teamName || !env.teamEmail || !env.pipelineId) {
+        println("Missing required variables to use ciStage")
+        sh "exit 1"
+    }
+    def runningTopic = env.topicPrefix + ".pipeline.stage.running"
+    def completeTopic = env.topicPrefix + ".pipeline.stage.complete"
+
+    // Create ci and pipeline arrays to place in messages
+    myCIArray = env.teamIRC ? msgBusCIContent(name: env.effortName, team: env.teamName, irc: env.teamIRC, email: env.teamEmail) : msgBusCIContent(name: env.effortName, team: env.teamName, email: env.teamEmail)
+    myStageArray = msgBusStageContent(name: stageName)
+    myPipelineArray = env.pipelineName ? msgBusPipelineContent(name: env.pipelineName, id: env.pipelineId, stage: myStageArray()) : msgBusPipelineContent(name: env.teamName, id: env.pipelineId, stage: myStageArray())
+
+    // Create stage running message
+    runningMsg = msgBusStageMsg(ci: myCIArray(), pipeline: myPipelineArray())
+    // send running message
+    //sendMessageWithAudit(msgTopic: runningTopic, msgContent: runningMsg())
+    println("topic is " + runningTopic)
+    println("running message is " + runningMsg())
+
+    // Get current time
+    long startTimeMillis = System.currentTimeMillis()
+
+    stage(stageName) {
+        body()
+    }
+
+    // Get end time
+    long endTimeMillis = System.currentTimeMillis()
+
+    float runTimeSeconds = ((endTimeMillis - startTimeMillis) / 1000)
+    // Recreate pipeline array with runtime in the stage
+    myStageArray = msgBusStageContent(name: stageName, runtime: runTimeSeconds)
+    myPipelineArray = env.pipelineName ? msgBusPipelineContent(name: env.pipelineName, id: env.pipelineId, stage: myStageArray()) : msgBusPipelineContent(name: env.teamName, id: env.pipelineId, stage: myStageArray())
+
+    // Create stage complete message
+    completeMsg = msgBusStageMsg(ci: myCIArray(), pipeline: myPipelineArray())
+    // Send complete message
+    //sendMessageWithAudit(msgTopic: completeTopic, msgContent: completeMsg())
+    println("complete message is " + completeMsg())
+}

--- a/vars/ciStage.groovy
+++ b/vars/ciStage.groovy
@@ -20,10 +20,10 @@
  */
 
 def call(String stageName, Closure body) {
-    // Make sure required env variables are set
-    if (!env.topicPrefix || !env.effortName || !env.teamName || !env.teamEmail || !env.pipelineId) {
-        println("Missing required variables to use ciStage")
-        sh "exit 1"
+    // Make sure required env variables are set. The ones used in the
+    // message bodies are enforced by the json closures.
+    if (!env.topicPrefix) {
+        error("Missing required variables to use ciStage")
     }
     def runningTopic = env.topicPrefix + ".pipeline.stage.running"
     def completeTopic = env.topicPrefix + ".pipeline.stage.complete"
@@ -36,9 +36,7 @@ def call(String stageName, Closure body) {
     // Create stage running message
     runningMsg = msgBusStageMsg(ci: myCIArray(), pipeline: myPipelineArray())
     // send running message
-    //sendMessageWithAudit(msgTopic: runningTopic, msgContent: runningMsg())
-    println("topic is " + runningTopic)
-    println("running message is " + runningMsg())
+    sendMessageWithAudit(msgTopic: runningTopic, msgContent: runningMsg())
 
     // Get current time
     long startTimeMillis = System.currentTimeMillis()
@@ -58,6 +56,5 @@ def call(String stageName, Closure body) {
     // Create stage complete message
     completeMsg = msgBusStageMsg(ci: myCIArray(), pipeline: myPipelineArray())
     // Send complete message
-    //sendMessageWithAudit(msgTopic: completeTopic, msgContent: completeMsg())
-    println("complete message is " + completeMsg())
+    sendMessageWithAudit(msgTopic: completeTopic, msgContent: completeMsg())
 }

--- a/vars/ciStage.groovy
+++ b/vars/ciStage.groovy
@@ -8,6 +8,9 @@
  * optional:
  * env.teamIRC: team's irc channel
  * env.pipelineName: For use if the pipeline name differs from the effort name
+ * env.MSG_PROVIDER: This is actually required by the sendMessage function that ciStage uses. It is the provider configured in Jenkins on which to send messages
+ * env.dataGrepperUrl: This is required by the sendMessageWithAudit function that ciStage uses. It tells the function where to look to confirm the message was sent as expected
+ *
  * Example Usage:
  *
  *  ciStage('run-stage') {
@@ -22,8 +25,9 @@
 def call(String stageName, Closure body) {
     // Make sure required env variables are set. The ones used in the
     // message bodies are enforced by the json closures.
+    // Note: Error message should be changed if variables are added here
     if (!env.topicPrefix) {
-        error("Missing required variables to use ciStage")
+        error("Missing topicPrefix required variable to use ciStage")
     }
     def runningTopic = env.topicPrefix + ".pipeline.stage.running"
     def completeTopic = env.topicPrefix + ".pipeline.stage.complete"
@@ -31,7 +35,7 @@ def call(String stageName, Closure body) {
     // Create ci and pipeline arrays to place in messages
     myCIArray = env.teamIRC ? msgBusCIContent(name: env.effortName, team: env.teamName, irc: env.teamIRC, email: env.teamEmail) : msgBusCIContent(name: env.effortName, team: env.teamName, email: env.teamEmail)
     myStageArray = msgBusStageContent(name: stageName)
-    myPipelineArray = env.pipelineName ? msgBusPipelineContent(name: env.pipelineName, id: env.pipelineId, stage: myStageArray()) : msgBusPipelineContent(name: env.teamName, id: env.pipelineId, stage: myStageArray())
+    myPipelineArray = env.pipelineName ? msgBusPipelineContent(name: env.pipelineName, id: env.pipelineId, stage: myStageArray()) : msgBusPipelineContent(name: env.effortName, id: env.pipelineId, stage: myStageArray())
 
     // Create stage running message
     runningMsg = msgBusStageMsg(ci: myCIArray(), pipeline: myPipelineArray())

--- a/vars/msgBusArtifactContent.groovy
+++ b/vars/msgBusArtifactContent.groovy
@@ -14,7 +14,11 @@ def call(Map parameters = [:]) {
 
     return { Map runtimeArgs = [:] ->
         parameters = utils.mapMergeQuotes([parameters, runtimeArgs])
-        mergedMessage = utils.mergeBusMessage(parameters, defaults)
+        try {
+            mergedMessage = utils.mergeBusMessage(parameters, defaults)
+        } catch(e) {
+            throw new Exception("Creating message for artifact array failed!")
+        }
 
         // sendCIMessage expects String arguments
         return utils.getMapStringColon(mergedMessage)

--- a/vars/msgBusCIContent.groovy
+++ b/vars/msgBusCIContent.groovy
@@ -17,7 +17,11 @@ def call(Map parameters = [:]) {
         parameters['url'] = parameters['url'] ?: env.JENKINS_URL
 
         parameters = utils.mapMergeQuotes([parameters, runtimeArgs])
-        mergedMessage = utils.mergeBusMessage(parameters, defaults)
+        try {
+            mergedMessage = utils.mergeBusMessage(parameters, defaults)
+        } catch(e) {
+            throw new Exception("Creating message for CI array failed!")
+        }
 
         // sendCIMessage expects String arguments
         return utils.getMapStringColon(mergedMessage)

--- a/vars/msgBusContainerContent.groovy
+++ b/vars/msgBusContainerContent.groovy
@@ -14,7 +14,11 @@ def call(Map parameters = [:]) {
 
     return { Map runtimeArgs = [:] ->
         parameters = utils.mapMergeQuotes([parameters, runtimeArgs])
-        mergedMessage = utils.mergeBusMessage(parameters, defaults)
+        try {
+            mergedMessage = utils.mergeBusMessage(parameters, defaults)
+        } catch(e) {
+            throw new Exception("Creating message for container array failed!")
+        }
 
         // sendCIMessage expects String arguments
         return utils.getMapStringColon(mergedMessage)

--- a/vars/msgBusHeader.groovy
+++ b/vars/msgBusHeader.groovy
@@ -17,7 +17,11 @@ def call(Map parameters = [:]) {
         parameters['topic'] = parameters['topic'] ?: "org.fedoraproject.prod.ci.koji-build.test.complete"
 
         parameters = utils.mapMerge([parameters, runtimeArgs])
-        mergedMessage = utils.mergeBusMessage(parameters, defaults)
+        try {
+            mergedMessage = utils.mergeBusMessage(parameters, defaults)
+        } catch(e) {
+            throw new Exception("Creating the message header failed!")
+        }
 
         // sendCIMessage expects String arguments
         return utils.getMapString(mergedMessage)

--- a/vars/msgBusPipelineContent.groovy
+++ b/vars/msgBusPipelineContent.groovy
@@ -15,8 +15,8 @@ def call(Map parameters = [:]) {
     return { Map runtimeArgs = [:] ->
         // Set defaults that can't go in json file
         parameters['name'] = parameters['name'] ?: env.JOB_NAME
-        parameters['status'] = parameters['status'] ?: (currentBuild.result ?: "running")
         parameters['build'] = parameters['build'] ?: env.BUILD_NUMBER
+        parameters['stage'] = parameters['stage'] ?: msgBusStageContent()()
 
         parameters = utils.mapMergeQuotes([parameters, runtimeArgs])
         mergedMessage = utils.mergeBusMessage(parameters, defaults)

--- a/vars/msgBusPipelineContent.groovy
+++ b/vars/msgBusPipelineContent.groovy
@@ -19,7 +19,11 @@ def call(Map parameters = [:]) {
         parameters['stage'] = parameters['stage'] ?: msgBusStageContent()()
 
         parameters = utils.mapMergeQuotes([parameters, runtimeArgs])
-        mergedMessage = utils.mergeBusMessage(parameters, defaults)
+        try {
+            mergedMessage = utils.mergeBusMessage(parameters, defaults)
+        } catch(e) {
+            throw new Exception("Creating message for pipeline array failed!")
+        }
 
         // sendCIMessage expects String arguments
         return utils.getMapStringColon(mergedMessage)

--- a/vars/msgBusPipelineMsg.groovy
+++ b/vars/msgBusPipelineMsg.groovy
@@ -16,7 +16,6 @@ def call(Map parameters = [:]) {
         // Set defaults that can't go in json file
         parameters['ci'] = parameters['ci'] ?: msgBusCIContent()()
         parameters['run'] = parameters['run'] ?: msgBusRunContent()()
-        parameters['artifact'] = parameters['artifact'] ?: msgBusArtifactContent()()
         parameters['pipeline'] = parameters['pipeline'] ?: msgBusPipelineContent()()
         parameters['generated_at'] = parameters['generated_at'] ?: java.time.Instant.now().toString()
 

--- a/vars/msgBusPipelineMsg.groovy
+++ b/vars/msgBusPipelineMsg.groovy
@@ -20,7 +20,11 @@ def call(Map parameters = [:]) {
         parameters['generated_at'] = parameters['generated_at'] ?: java.time.Instant.now().toString()
 
         parameters = utils.mapMergeQuotes([parameters, runtimeArgs])
-        mergedMessage = utils.mergeBusMessage(parameters, defaults)
+        try {
+            mergedMessage = utils.mergeBusMessage(parameters, defaults)
+        } catch(e) {
+            throw new Exception("Creating the pipeline message failed!")
+        }
 
         // sendCIMessage expects String arguments
         return utils.getMapStringColon(mergedMessage)

--- a/vars/msgBusRunContent.groovy
+++ b/vars/msgBusRunContent.groovy
@@ -19,7 +19,11 @@ def call(Map parameters = [:]) {
         parameters['rebuild'] = parameters['rebuild'] ?: env.BUILD_URL + 'rebuild/parameterized'
 
         parameters = utils.mapMergeQuotes([parameters, runtimeArgs])
-        mergedMessage = utils.mergeBusMessage(parameters, defaults)
+        try {
+            mergedMessage = utils.mergeBusMessage(parameters, defaults)
+        } catch(e) {
+            throw new Exception("Creating message for run array failed!")
+        }
 
         // sendCIMessage expects String arguments
         return utils.getMapStringColon(mergedMessage)

--- a/vars/msgBusStageContent.groovy
+++ b/vars/msgBusStageContent.groovy
@@ -14,7 +14,11 @@ def call(Map parameters = [:]) {
 
     return { Map runtimeArgs = [:] ->
         parameters = utils.mapMergeQuotes([parameters, runtimeArgs])
-        mergedMessage = utils.mergeBusMessage(parameters, defaults)
+        try {
+            mergedMessage = utils.mergeBusMessage(parameters, defaults)
+        } catch(e) {
+            throw new Exception("Creating message for stage array failed!")
+        }
 
         // sendCIMessage expects String arguments
         return utils.getMapStringColon(mergedMessage)

--- a/vars/msgBusStageContent.groovy
+++ b/vars/msgBusStageContent.groovy
@@ -13,8 +13,6 @@ def call(Map parameters = [:]) {
     def defaults = readJSON text: libraryResource('msgBusStageContent.json')
 
     return { Map runtimeArgs = [:] ->
-        parameters['status'] = parameters['status'] ?: (currentBuild.currentResult == "SUCCESS") ? "complete" : "error"
-
         parameters = utils.mapMergeQuotes([parameters, runtimeArgs])
         mergedMessage = utils.mergeBusMessage(parameters, defaults)
 

--- a/vars/msgBusStageMsg.groovy
+++ b/vars/msgBusStageMsg.groovy
@@ -20,7 +20,11 @@ def call(Map parameters = [:]) {
         parameters['generated_at'] = parameters['generated_at'] ?: java.time.Instant.now().toString()
 
         parameters = utils.mapMergeQuotes([parameters, runtimeArgs])
-        mergedMessage = utils.mergeBusMessage(parameters, defaults)
+        try {
+            mergedMessage = utils.mergeBusMessage(parameters, defaults)
+        } catch(e) {
+            throw new Exception("Creating the stage message failed!")
+        }
 
         // sendCIMessage expects String arguments
         return utils.getMapStringColon(mergedMessage)

--- a/vars/msgBusStageMsg.groovy
+++ b/vars/msgBusStageMsg.groovy
@@ -16,9 +16,7 @@ def call(Map parameters = [:]) {
         // Set defaults that can't go in json file
         parameters['ci'] = parameters['ci'] ?: msgBusCIContent()()
         parameters['run'] = parameters['run'] ?: msgBusRunContent()()
-        parameters['artifact'] = parameters['artifact'] ?: msgBusArtifactContent()()
         parameters['pipeline'] = parameters['pipeline'] ?: msgBusPipelineContent()()
-        parameters['stage'] = parameters['stage'] ?: msgBusStageContent()()
         parameters['generated_at'] = parameters['generated_at'] ?: java.time.Instant.now().toString()
 
         parameters = utils.mapMergeQuotes([parameters, runtimeArgs])

--- a/vars/msgBusSystemContent.groovy
+++ b/vars/msgBusSystemContent.groovy
@@ -14,7 +14,11 @@ def call(Map parameters = [:]) {
 
     return { Map runtimeArgs = [:] ->
         parameters = utils.mapMergeQuotes([parameters, runtimeArgs])
-        mergedMessage = utils.mergeBusMessage(parameters, defaults)
+        try {
+            mergedMessage = utils.mergeBusMessage(parameters, defaults)
+        } catch(e) {
+            throw new Exception("Creating message for system array failed!")
+        }
 
         // sendCIMessage expects String arguments
         return utils.getMapStringColon(mergedMessage)

--- a/vars/msgBusTestComplete.groovy
+++ b/vars/msgBusTestComplete.groovy
@@ -23,7 +23,11 @@ def call(Map parameters = [:]) {
         parameters['status'] = parameters['status'] ?: utils.getBuildStatus()
 
         parameters = utils.mapMergeQuotes([parameters, runtimeArgs])
-        mergedMessage = utils.mergeBusMessage(parameters, defaults)
+        try {
+            mergedMessage = utils.mergeBusMessage(parameters, defaults)
+        } catch(e) {
+            throw new Exception("Creating the test complete message failed!")
+        }
 
         // sendCIMessage expects String arguments
         return utils.getMapStringColon(mergedMessage)

--- a/vars/msgBusTestContent.groovy
+++ b/vars/msgBusTestContent.groovy
@@ -17,7 +17,11 @@ def call(Map parameters = [:]) {
         parameters['raw'] = parameters['raw'] ?: utils.getBuildStatus()
 
         parameters = utils.mapMergeQuotes([parameters, runtimeArgs])
-        mergedMessage = utils.mergeBusMessage(parameters, defaults)
+        try {
+            mergedMessage = utils.mergeBusMessage(parameters, defaults)
+        } catch(e) {
+            throw new Exception("Creating message for test array failed!")
+        }
 
         // sendCIMessage expects String arguments
         return utils.getMapStringColon(mergedMessage)

--- a/vars/msgBusTestError.groovy
+++ b/vars/msgBusTestError.groovy
@@ -21,7 +21,11 @@ def call(Map parameters = [:]) {
         parameters['reason'] = parameters['reason'] ?: "Unknown execution error"
 
         parameters = utils.mapMergeQuotes([parameters, runtimeArgs])
-        mergedMessage = utils.mergeBusMessage(parameters, defaults)
+        try {
+            mergedMessage = utils.mergeBusMessage(parameters, defaults)
+        } catch(e) {
+            throw new Exception("Creating the test error message failed!")
+        }
 
         // sendCIMessage expects String arguments
         return utils.getMapStringColon(mergedMessage)

--- a/vars/msgBusTestQueued.groovy
+++ b/vars/msgBusTestQueued.groovy
@@ -20,7 +20,11 @@ def call(Map parameters = [:]) {
         parameters['generated_at'] = parameters['generated_at'] ?: java.time.Instant.now().toString()
 
         parameters = utils.mapMergeQuotes([parameters, runtimeArgs])
-        mergedMessage = utils.mergeBusMessage(parameters, defaults)
+        try {
+            mergedMessage = utils.mergeBusMessage(parameters, defaults)
+        } catch(e) {
+            throw new Exception("Creating the test queued message failed!")
+        }
 
         // sendCIMessage expects String arguments
         return utils.getMapStringColon(mergedMessage)

--- a/vars/msgBusTestRunning.groovy
+++ b/vars/msgBusTestRunning.groovy
@@ -20,7 +20,11 @@ def call(Map parameters = [:]) {
         parameters['generated_at'] = parameters['generated_at'] ?: java.time.Instant.now().toString()
 
         parameters = utils.mapMergeQuotes([parameters, runtimeArgs])
-        mergedMessage = utils.mergeBusMessage(parameters, defaults)
+        try {
+            mergedMessage = utils.mergeBusMessage(parameters, defaults)
+        } catch(e) {
+            throw new Exception("Creating the test running message failed!")
+        }
 
         // sendCIMessage expects String arguments
         return utils.getMapStringColon(mergedMessage)

--- a/vars/sendMessageWithAudit.groovy
+++ b/vars/sendMessageWithAudit.groovy
@@ -11,8 +11,8 @@ import org.centos.contra.pipeline.Utils
 
 def call(Map parameters = [:]) {
     def msgTopic = parameters.get('msgTopic')
-    def msgProps = parameters.get('msgProps') ?: ""
-    def msgContent = parameters.get('msgContent') ?: ""
+    def msgProps = parameters.get('msgProps', '')
+    def msgContent = parameters.get('msgContent', '')
     def msgAuditFile = parameters.get('msgAuditFile', 'auditfile.json')
     def msgRetryCount = parameters.get('msgRetryCount', 3)
 

--- a/vars/sendMessageWithAudit.groovy
+++ b/vars/sendMessageWithAudit.groovy
@@ -11,16 +11,25 @@ import org.centos.contra.pipeline.Utils
 
 def call(Map parameters = [:]) {
     def msgTopic = parameters.get('msgTopic')
-    def msgProps = parameters.get('msgProps')
-    def msgContent = parameters.get('msgContent')
+    def msgProps = parameters.get('msgProps') ?: ""
+    def msgContent = parameters.get('msgContent') ?: ""
     def msgAuditFile = parameters.get('msgAuditFile', 'auditfile.json')
     def msgRetryCount = parameters.get('msgRetryCount', 3)
 
-    // Get contents of auditFile
-    def auditContent = readJSON file: msgAuditFile
+    def utils = new Utils()
+
+    def auditContent = null
+    try {
+        // Get contents of auditFile
+        auditContent = readJSON file: msgAuditFile
+    } catch(e) {
+        // If could not read audit file, create it
+        utils.initializeAuditFile(msgAuditFile)
+        auditContent = readJSON file: msgAuditFile
+    }
 
     // Send message and get handle on SendResult
-    def sendResult = sendMessage(msgTopic, msgProps, msgContent)
+    def sendResult = utils.sendMessage(msgTopic, msgProps, msgContent)
 
     String id = sendResult.getMessageId()
     String msg = sendResult.getMessageContent()
@@ -32,5 +41,5 @@ def call(Map parameters = [:]) {
 
     archiveArtifacts allowEmptyArchive: false, artifacts: msgAuditFile
 
-    trackMessage(id, msgRetryCount)
+    utils.trackMessage(id, msgRetryCount)
 }

--- a/vars/setEnvVars.groovy
+++ b/vars/setEnvVars.groovy
@@ -10,7 +10,7 @@
  *
  * Example Usage:
  *
- *  setMsgEnvVars(stageName: 'run-stage') {
+ *  setEnvVars(stageName: 'run-stage') {
  *      runCode()
  *  }
  *

--- a/vars/setMsgEnvVars.groovy
+++ b/vars/setMsgEnvVars.groovy
@@ -1,0 +1,26 @@
+/**
+ * msgBus vars in use:
+ * topicPrefix: The prefix of the message topic. Choices include org.fedoraproject.prod.ci and VirtualTopic.eng.ci
+ * effortName: Name of the effort or pipeline
+ * teamName
+ * teamEmail
+ * pipelineId: UUID for this pipeline run
+ * teamIRC: team's irc channel
+ * pipelineName: For use if the pipeline name differs from the effort name
+ *
+ * Example Usage:
+ *
+ *  setMsgEnvVars(stageName: 'run-stage') {
+ *      runCode()
+ *  }
+ *
+ * @param parameters
+ * var: value which still set env.var = value
+ * @return
+ */
+
+def call(Map parameters = [:]) {
+    parameters.each { key, value ->
+        env."${key}" = parameters.get(key)
+    }
+}


### PR DESCRIPTION
- Improve error reporting, so if you forget a required variable in a message, instead of just ```Required value missing for <var>, <value>``` it will also tell you which type of message was attempting to be created when the error was hit

- Fix sendMessageWithAudit and add required functions for it

- Add setEnvVars function that will set any variables passed to it to the environment. For example, ```setEnvVars(foo: 'bar')``` sets ```env.foo = 'bar'```

- Add ciStage function. This requires setting some variables (listed in ciStage.groovy), but when the proper variables are set, one can call ```ciStage('my-stage') {
    <some code>
}```
and the stage will run with a pipeline.stage.running message sent out when the stage starts and a pipeline.stage.complete message sent out when the stage completes. Also, values like the stage runtime will be populated for free.

- I will post a follow up PR with README changes, but I did not want to hold up the review of the code until I finish it