### PR TITLE
Inject all vars in kojiMessage

### DIFF
--- a/src/org/centos/contra/pipeline/Utils.groovy
+++ b/src/org/centos/contra/pipeline/Utils.groovy
@@ -44,8 +44,8 @@ def flattenJSON(String message) {
 
 /**
  * Traverse a CI_MESSAGE with nested keys.
- * @param prefix
- * @param message
+ * @param ci_data
+ * @param ciMessage
  * @return env map with all keys at top level
  */
 def injectCIMessage(def ci_data, def ciMessage) {
@@ -65,6 +65,19 @@ def injectCIMessage(def ci_data, def ciMessage) {
     }
 
     return ci_data
+}
+
+/**
+ * Inject array values
+ * @param ci_data
+ * @param message
+ * @return
+ */
+def injectArray(def ci_data, def message) {
+    message.eachWithIndex { value, index ->
+        ci_data[value] =
+            value.toString().split('\n')[0].replaceAll('"', '\'')
+    }
 }
 
 /**

--- a/vars/kojiMessage.groovy
+++ b/vars/kojiMessage.groovy
@@ -4,15 +4,24 @@ import org.centos.contra.pipeline.Utils
 def call(Map parameters = [:]) {
 
     def message = parameters.get('message', '{}')
+    def ignoreErrors = parameters.get('ignoreErrors', false)
 
     def utils = new Utils()
 
     def parsedMsg = utils.flattenJSON(message)
 
-    parsedMsg['repo'] = utils.repoFromRequest(parsedMsg['request'][0])
-    def branch = utils.setBuildBranch(parsedMsg['request'][1])
-    parsedMsg['branch'] = branch[0]
-    parsedMsg['repo_branch'] = branch[1]
+    try {
+        parsedMsg['repo'] = utils.repoFromRequest(parsedMsg['request'][0])
+        def branch = utils.setBuildBranch(parsedMsg['request'][1])
+        parsedMsg['branch'] = branch[0]
+        parsedMsg['repo_branch'] = branch[1]
+    } catch (e) {
+        if (ignoreErrors) {
+            println("Ignoring error message: " + e)
+        } else {
+            throw e
+        }
+    }
 
     return parsedMsg
 }

--- a/vars/kojiMessage.groovy
+++ b/vars/kojiMessage.groovy
@@ -8,7 +8,7 @@ def call(Map parameters = [:]) {
 
     def utils = new Utils()
 
-    def parsedMsg = utils.flattenJSON(message)
+    def parsedMsg = readJSON text: message.replace("\n", "\\n")
 
     try {
         parsedMsg['repo'] = utils.repoFromRequest(parsedMsg['request'][0])

--- a/vars/kojiMessage.groovy
+++ b/vars/kojiMessage.groovy
@@ -7,7 +7,7 @@ def call(Map parameters = [:]) {
 
     def utils = new Utils()
 
-    def parsedMsg = readJSON text: message.replace("\n", "\\n")
+    def parsedMsg = utils.flattenJSON(message)
 
     parsedMsg['repo'] = utils.repoFromRequest(parsedMsg['request'][0])
     def branch = utils.setBuildBranch(parsedMsg['request'][1])


### PR DESCRIPTION
kojiMessage.groovy allows extracting variables from a CI_MESSAGE. I would like to extract all the variables, not just the three listed. I also made it optional to override failures during finding those three variables to allow this function to work for other types of messages. As a side note, every message I tried failed finding repo, branch, and repo_branch, so I am not totally sure how functional that part is, but I left it included assuming it works for some type of message this function was originally intended to ingest.