### PR TITLE
Fix mkdir command in executeInContainer to skip if directory exists

### DIFF
--- a/vars/executeInContainer.groovy
+++ b/vars/executeInContainer.groovy
@@ -36,7 +36,7 @@ def call(Map parameters) {
 
             def containerEnv = localVars.collect { key, value -> return key+'='+value }
 
-            sh "mkdir ${stageDir}"
+            sh "mkdir -p ${stageDir}"
 
             try {
                 withEnv(containerEnv) {


### PR DESCRIPTION
Fix `mkdir` command in `executeInContainer` to skip if directory exists. This allows for multiple calls of the function in the same stage.