### PR TITLE
Make pipeline status msgs easier in declarative

### DIFF
--- a/vars/msgBusPipelineContent.groovy
+++ b/vars/msgBusPipelineContent.groovy
@@ -16,6 +16,7 @@ def call(Map parameters = [:]) {
         // Set defaults that can't go in json file
         parameters['name'] = parameters['name'] ?: env.JOB_NAME
         parameters['build'] = parameters['build'] ?: env.BUILD_NUMBER
+        parameters['id'] = parameters['id'] ?: UUID.randomUUID().toString()
 
         parameters = utils.mapMergeQuotes([parameters, runtimeArgs])
         try {

--- a/vars/sendPipelineStatusMsg.groovy
+++ b/vars/sendPipelineStatusMsg.groovy
@@ -20,9 +20,13 @@ def call(String topicSuffix) {
     try {
         def msgTopic = env.topicPrefix + ".pipeline." + topicSuffix
         def myCIArray = env.teamIRC ? msgBusCIContent(name: env.effortName, team: env.teamName, irc: env.teamIRC, email: env.teamEmail) : msgBusCIContent(name: env.effortName, team: env.teamName, email: env.teamEmail)
-        // Get runtime for pipeline array
-        float runTimeSeconds = (currentBuild.getDuration() / 1000)
-        def myPipelineArray = env.pipelineName ? msgBusPipelineContent(name: env.pipelineName, id: env.pipelineId) : msgBusPipelineContent(name: env.effortName, id: env.pipelineId, runtime: runTimeSeconds)
+        if (topicSuffix in ['complete','error']) {
+            // Get runtime for pipeline array
+            float runTimeSeconds = (currentBuild.getDuration() / 1000)
+            myPipelineArray = env.pipelineName ? msgBusPipelineContent(name: env.pipelineName, id: env.pipelineId, runtime: runTimeSeconds) : msgBusPipelineContent(name: env.effortName, id: env.pipelineId, runtime: runTimeSeconds)
+        } else {
+            myPipelineArray = env.pipelineName ? msgBusPipelineContent(name: env.pipelineName, id: env.pipelineId) : msgBusPipelineContent(name: env.effortName, id: env.pipelineId)
+        }
 
         // Create message
         pipelineMsg = msgBusPipelineMsg(ci: myCIArray(), pipeline: myPipelineArray())

--- a/vars/sendPipelineStatusMsg.groovy
+++ b/vars/sendPipelineStatusMsg.groovy
@@ -1,0 +1,35 @@
+/**
+ * requires: env.topicPrefix
+ * Example Usage:
+ *
+ * sendPipelineStatusMsg('complete') {
+ * }
+ *
+ * @param topicSuffix: String - One of [queued,running,complete,error]
+ * @return
+ */
+
+def call(String topicSuffix) {
+    // Make sure required env variables are set. The ones used in the
+    // message bodies are enforced by the json closures.
+    // Note: Error message should be changed if variables are added here
+    if (!env.topicPrefix) {
+        error("Missing env.topicPrefix required variable to use sendPipelineStatusMsg")
+    }
+
+    try {
+        def msgTopic = env.topicPrefix + ".pipeline." + topicSuffix
+        def myCIArray = env.teamIRC ? msgBusCIContent(name: env.effortName, team: env.teamName, irc: env.teamIRC, email: env.teamEmail) : msgBusCIContent(name: env.effortName, team: env.teamName, email: env.teamEmail)
+        // Get runtime for pipeline array
+        float runTimeSeconds = (currentBuild.getDuration() / 1000)
+        def myPipelineArray = env.pipelineName ? msgBusPipelineContent(name: env.pipelineName, id: env.pipelineId) : msgBusPipelineContent(name: env.effortName, id: env.pipelineId, runtime: runTimeSeconds)
+
+        // Create message
+        pipelineMsg = msgBusPipelineMsg(ci: myCIArray(), pipeline: myPipelineArray())
+        // Send message
+        sendMessageWithAudit(msgTopic: msgTopic, msgContent: pipelineMsg())
+
+    } catch(e) {
+        println("No message was sent out on topic " + env.topicPrefix + ".pipeline." + topicSuffix + ". The error encountered was: " + e)
+    }
+}


### PR DESCRIPTION
I'm not sure if we want runtime in all messages or just [complete,error]; still waiting for a reply.

This should make it easier to add the pipeline status messages in declarative. It would go something like:

```
pipeline {
    steps {
       script {
           sendPipelineStatusMsg('running')
        }
    }
    options { .. }
    agent { .. }
    stages { .. }
    post {
        failure {
            script {
                sendPipelineStatusMsg('error')
            }
        }
    }
}
```