### PR TITLE
Spec change for some of the test keys

### DIFF
--- a/resources/msgBusTestComplete.json
+++ b/resources/msgBusTestComplete.json
@@ -5,40 +5,10 @@
     "description": "Timestamp of message creation (ISO-8601)",
     "required": true
   },
-  "type": {
-    "value": null,
-    "type": "java.lang.String",
-    "description": "A string identifying the tests being run in this execution. Examples: tier1, tier2, pipeline",
-    "required": true
-  },
-  "category": {
-    "value": null,
-    "type": "java.lang.String",
-    "description": "Values: static-analysis, functional, integration, validation",
-    "required": true
-  },
-  "status": {
-    "value": null,
-    "type": "java.lang.String",
-    "description": "Values: passed, failed, info, needs_inspection, not_applicable",
-    "required": true
-  },
-  "label": {
-    "value": null,
-    "type": "java.lang.String",
-    "description": "Additional test label",
-    "required": false
-  },
   "web_url": {
     "value": null,
     "type": "java.lang.String",
     "description": "URL to a web UI with detailed results",
-    "required": false
-  },
-  "xunit": {
-    "value": null,
-    "type": "java.lang.String",
-    "description": "gzipped xunit with detailed results or URL link to xunit/junit results",
     "required": false
   },
   "recipients": {
@@ -58,12 +28,6 @@
     "type": "java.lang.String",
     "description": "Arbitrary note",
     "required": false
-  },
-  "namespace": {
-    "value": null,
-    "type": "java.lang.String",
-    "description": "A namespace used to prefix the ResultsDB testcase name. This is usually something identifying your team",
-    "required": true
   },
   "version": {
     "value": '"0.1.0"',
@@ -101,22 +65,10 @@
     "description": "The pipeline content Map",
     "required": true
   },
-  "stage": {
-    "value": {},
-    "type": "groovy.lang.Closure",
-    "description": "The stage content Map",
-    "required": true
-  },
   "test": {
     "value": {},
     "type": "groovy.lang.Closure",
     "description": "The test content Map",
-    "required": false
-  },
-  "container": {
-    "value": {},
-    "type": "groovy.lang.Closure",
-    "description": "The test.container content Map",
     "required": false
   }
 }

--- a/resources/msgBusTestContent.json
+++ b/resources/msgBusTestContent.json
@@ -26,7 +26,25 @@
   "category": {
     "value": null,
     "type": "java.lang.String",
-    "description": "N/A",
+    "description": "Values: static-analysis, functional, integration, validation",
+    "required": true
+  },
+  "namespace": {
+    "value": null,
+    "type": "java.lang.String",
+    "description": "A namespace used to prefix the ResultsDB testcase name. This is usually something identifying your team",
+    "required": true
+  },
+  "type": {
+    "value": null,
+    "type": "java.lang.String",
+    "description": "A string identifying the tests being run in this execution. Example: tier1, tier2, pipeline",
+    "required": true
+  },
+  "label": {
+    "value": null,
+    "type": "java.lang.String",
+    "description": "Additional test label",
     "required": false
   },
   "xunit_files": {
@@ -45,6 +63,12 @@
     "value": 0.0,
     "type": "java.math.BigDecimal",
     "description": "The runtime of the test",
+    "required": false
+  },
+  "lifetime": {
+    "value": 0,
+    "type": "java.math.BigInteger",
+    "description": "number of minutes the test is expected to run",
     "required": false
   }
 }

--- a/resources/msgBusTestError.json
+++ b/resources/msgBusTestError.json
@@ -5,24 +5,6 @@
     "description": "Timestamp of message creation (ISO-8601)",
     "required": true
   },
-  "type": {
-    "value": null,
-    "type": "java.lang.String",
-    "description": "A string identifying the tests being run in this execution. Examples: tier1, tier2, pipeline",
-    "required": true
-  },
-  "category": {
-    "value": null,
-    "type": "java.lang.String",
-    "description": "Values: static-analysis, functional, integration, validation",
-    "required": true
-  },
-  "label": {
-    "value": null,
-    "type": "java.lang.String",
-    "description": "Additional test label",
-    "required": false
-  },
   "recipients": {
     "value": [],
     "type": "java.util.ArrayList",
@@ -41,22 +23,10 @@
     "description": "Arbitrary note",
     "required": false
   },
-  "namespace": {
-    "value": null,
-    "type": "java.lang.String",
-    "description": "A namespace used to prefix the ResultsDB testcase name. This is usually something identifying your team",
-    "required": true
-  },
   "version": {
     "value": '"0.1.0"',
     "type": "java.lang.String",
     "description": "Version of the specification",
-    "required": true
-  },
-  "reason": {
-    "value": null,
-    "type": "java.lang.String",
-    "description": "Reason of the failure",
     "required": true
   },
   "issue_url": {
@@ -81,6 +51,12 @@
     "value": {},
     "type": "groovy.lang.Closure",
     "description": "The artifact content Map",
+    "required": true
+  },
+  "test": {
+    "value": {},
+    "type": "groovy.lang.Closure",
+    "description": "The test content Map",
     "required": true
   }
 }

--- a/resources/msgBusTestError.json
+++ b/resources/msgBusTestError.json
@@ -29,6 +29,12 @@
     "description": "Version of the specification",
     "required": true
   },
+  "reason": {
+    "value": null,
+    "type": "java.lang.String",
+    "description": "Reason of the failure",
+    "required": true
+  },
   "issue_url": {
     "value": null,
     "type": "java.lang.String",
@@ -51,6 +57,12 @@
     "value": {},
     "type": "groovy.lang.Closure",
     "description": "The artifact content Map",
+    "required": true
+  },
+  "pipeline": {
+    "value": {},
+    "type": "groovy.lang.Closure",
+    "description": "The pipeline content Map",
     "required": true
   },
   "test": {

--- a/resources/msgBusTestQueued.json
+++ b/resources/msgBusTestQueued.json
@@ -41,6 +41,12 @@
     "description": "The artifact content Map",
     "required": true
   },
+  "pipeline": {
+    "value": {},
+    "type": "groovy.lang.Closure",
+    "description": "The pipeline content Map",
+    "required": true
+  },
   "test": {
     "value": {},
     "type": "groovy.lang.Closure",

--- a/resources/msgBusTestQueued.json
+++ b/resources/msgBusTestQueued.json
@@ -5,24 +5,6 @@
     "description": "Timestamp of message creation (ISO-8601)",
     "required": true
   },
-  "type": {
-    "value": null,
-    "type": "java.lang.String",
-    "description": "A string identifying the tests being run in this execution. Examples: tier1, tier2, pipeline",
-    "required": true
-  },
-  "category": {
-    "value": null,
-    "type": "java.lang.String",
-    "description": "Values: static-analysis, functional, integration, validation",
-    "required": true
-  },
-  "label": {
-    "value": null,
-    "type": "java.lang.String",
-    "description": "Additional test label",
-    "required": false
-  },
   "thread_id": {
     "value": null,
     "type": "java.lang.String",
@@ -34,12 +16,6 @@
     "type": "java.lang.String",
     "description": "Arbitrary note",
     "required": false
-  },
-  "namespace": {
-    "value": null,
-    "type": "java.lang.String",
-    "description": "A namespace used to prefix the ResultsDB testcase name. This is usually something identifying your team",
-    "required": true
   },
   "version": {
     "value": '"0.1.0"',
@@ -63,6 +39,12 @@
     "value": {},
     "type": "groovy.lang.Closure",
     "description": "The artifact content Map",
+    "required": true
+  },
+  "test": {
+    "value": {},
+    "type": "groovy.lang.Closure",
+    "description": "The test content Map",
     "required": true
   }
 }

--- a/resources/msgBusTestRunning.json
+++ b/resources/msgBusTestRunning.json
@@ -41,6 +41,12 @@
     "description": "The artifact content Map",
     "required": true
   },
+  "pipeline": {
+    "value": {},
+    "type": "groovy.lang.Closure",
+    "description": "The pipeline content Map",
+    "required": true
+  },
   "test": {
     "value": {},
     "type": "groovy.lang.Closure",

--- a/resources/msgBusTestRunning.json
+++ b/resources/msgBusTestRunning.json
@@ -5,24 +5,6 @@
     "description": "Timestamp of message creation (ISO-8601)",
     "required": true
   },
-  "type": {
-    "value": null,
-    "type": "java.lang.String",
-    "description": "A string identifying the tests being run in this execution. Examples: tier1, tier2, pipeline",
-    "required": true
-  },
-  "category": {
-    "value": null,
-    "type": "java.lang.String",
-    "description": "Values: static-analysis, functional, integration, validation",
-    "required": true
-  },
-  "label": {
-    "value": null,
-    "type": "java.lang.String",
-    "description": "Additional test label",
-    "required": false
-  },
   "thread_id": {
     "value": null,
     "type": "java.lang.String",
@@ -35,23 +17,11 @@
     "description": "Arbitrary note",
     "required": false
   },
-  "namespace": {
-    "value": null,
-    "type": "java.lang.String",
-    "description": "A namespace used to prefix the ResultsDB testcase name. This is usually something identifying your team",
-    "required": true
-  },
   "version": {
     "value": '"0.1.0"',
     "type": "java.lang.String",
     "description": "Version of the specification",
     "required": true
-  },
-  "lifetime": {
-    "value": 0,
-    "type": "java.math.BigInteger",
-    "description": "Number of minutes the test is expected to run",
-    "required": false
   },
   "ci": {
     "value": {},
@@ -69,6 +39,12 @@
     "value": {},
     "type": "groovy.lang.Closure",
     "description": "The artifact content Map",
+    "required": true
+  },
+  "test": {
+    "value": {},
+    "type": "groovy.lang.Closure",
+    "description": "The test content Map",
     "required": true
   }
 }

--- a/vars/msgBusTestComplete.groovy
+++ b/vars/msgBusTestComplete.groovy
@@ -21,6 +21,8 @@ def call(Map parameters = [:]) {
         parameters['system'] = parameters['system'] ?: msgBusSystemContent()()
         parameters['generated_at'] = parameters['generated_at'] ?: java.time.Instant.now().toString()
         parameters['status'] = parameters['status'] ?: utils.getBuildStatus()
+        parameters['thread_id'] = parameters['thread_id'] ?: UUID.randomUUID().t
+oString()
 
         parameters = utils.mapMergeQuotes([parameters, runtimeArgs])
         try {

--- a/vars/msgBusTestError.groovy
+++ b/vars/msgBusTestError.groovy
@@ -19,6 +19,8 @@ def call(Map parameters = [:]) {
         parameters['artifact'] = parameters['artifact'] ?: msgBusArtifactContent()()
         parameters['generated_at'] = parameters['generated_at'] ?: java.time.Instant.now().toString()
         parameters['reason'] = parameters['reason'] ?: "Unknown execution error"
+        parameters['thread_id'] = parameters['thread_id'] ?: UUID.randomUUID().t
+oString()
 
         parameters = utils.mapMergeQuotes([parameters, runtimeArgs])
         try {

--- a/vars/msgBusTestQueued.groovy
+++ b/vars/msgBusTestQueued.groovy
@@ -18,6 +18,7 @@ def call(Map parameters = [:]) {
         parameters['run'] = parameters['run'] ?: msgBusRunContent()()
         parameters['artifact'] = parameters['artifact'] ?: msgBusArtifactContent()()
         parameters['generated_at'] = parameters['generated_at'] ?: java.time.Instant.now().toString()
+        parameters['thread_id'] = parameters['thread_id'] ?: UUID.randomUUID().toString()
 
         parameters = utils.mapMergeQuotes([parameters, runtimeArgs])
         try {

--- a/vars/msgBusTestRunning.groovy
+++ b/vars/msgBusTestRunning.groovy
@@ -18,6 +18,7 @@ def call(Map parameters = [:]) {
         parameters['run'] = parameters['run'] ?: msgBusRunContent()()
         parameters['artifact'] = parameters['artifact'] ?: msgBusArtifactContent()()
         parameters['generated_at'] = parameters['generated_at'] ?: java.time.Instant.now().toString()
+        parameters['thread_id'] = parameters['thread_id'] ?: UUID.randomUUID().toString()
 
         parameters = utils.mapMergeQuotes([parameters, runtimeArgs])
         try {


### PR DESCRIPTION
A change was made to the spec to move a lot of the root level stuff in test.* messages into the test array. Only type, namespace, and category were present and required in all test.* messages, so those are the only ones I marked as required: true in the test content json file.