### PR TITLE
Make fields in build but not pr spec not req

### DIFF
--- a/resources/msgBusArtifactContent.json
+++ b/resources/msgBusArtifactContent.json
@@ -18,7 +18,7 @@
       "value": null,
       "type": "java.lang.String",
       "description": "Name of the component tested",
-      "required": true
+      "required": false
     },
   "issuer":
     {
@@ -32,14 +32,14 @@
       "value": null,
       "type": "java.lang.String",
       "description": "Name-version-release of the artifact",
-      "required": true
+      "required": false
     },
   "scratch":
     {
       "value": true,
       "type": "java.lang.Boolean",
       "description": "Indication if the build is a scratch build",
-      "required": true
+      "required": false
     },
   "baseline":
     {


### PR DESCRIPTION
Didn't realize the fields req in koji-build spec aren't in dist-git-pr spec (so can't be req for artifact)

Signed-off-by: Johnny Bieren <jbieren@redhat.com>