### PR TITLE
Spec version should have been incremented

### DIFF
--- a/resources/msgBusTestComplete.json
+++ b/resources/msgBusTestComplete.json
@@ -30,7 +30,7 @@
     "required": false
   },
   "version": {
-    "value": '"0.1.0"',
+    "value": '"0.2.0"',
     "type": "java.lang.String",
     "description": "Version of the specification",
     "required": true

--- a/resources/msgBusTestError.json
+++ b/resources/msgBusTestError.json
@@ -24,7 +24,7 @@
     "required": false
   },
   "version": {
-    "value": '"0.1.0"',
+    "value": '"0.2.0"',
     "type": "java.lang.String",
     "description": "Version of the specification",
     "required": true

--- a/resources/msgBusTestQueued.json
+++ b/resources/msgBusTestQueued.json
@@ -18,7 +18,7 @@
     "required": false
   },
   "version": {
-    "value": '"0.1.0"',
+    "value": '"0.2.0"',
     "type": "java.lang.String",
     "description": "Version of the specification",
     "required": true

--- a/resources/msgBusTestRunning.json
+++ b/resources/msgBusTestRunning.json
@@ -18,7 +18,7 @@
     "required": false
   },
   "version": {
-    "value": '"0.1.0"',
+    "value": '"0.2.0"',
     "type": "java.lang.String",
     "description": "Version of the specification",
     "required": true


### PR DESCRIPTION
Once messages started flowing using the functions in here, people realized the spec version listed should be changed from 0.1.0 to 0.2.0 to help the listeners out

Signed-off-by: Johnny Bieren <jbieren@redhat.com>