### PR TITLE
Remove thread_id, add topic to error statement

### DIFF
--- a/resources/msgBusTestComplete.json
+++ b/resources/msgBusTestComplete.json
@@ -17,12 +17,6 @@
     "description": "A list of notification recipients",
     "required": false
   },
-  "thread_id": {
-    "value": null,
-    "type": "java.lang.String",
-    "description": "Unique identification string",
-    "required": false
-  },
   "note": {
     "value": null,
     "type": "java.lang.String",

--- a/resources/msgBusTestError.json
+++ b/resources/msgBusTestError.json
@@ -11,12 +11,6 @@
     "description": "A list of notification recipients",
     "required": false
   },
-  "thread_id": {
-    "value": null,
-    "type": "java.lang.String",
-    "description": "Unique identification string",
-    "required": false
-  },
   "note": {
     "value": null,
     "type": "java.lang.String",

--- a/resources/msgBusTestQueued.json
+++ b/resources/msgBusTestQueued.json
@@ -5,12 +5,6 @@
     "description": "Timestamp of message creation (ISO-8601)",
     "required": true
   },
-  "thread_id": {
-    "value": null,
-    "type": "java.lang.String",
-    "description": "Unique identification string",
-    "required": false
-  },
   "note": {
     "value": null,
     "type": "java.lang.String",

--- a/resources/msgBusTestRunning.json
+++ b/resources/msgBusTestRunning.json
@@ -5,12 +5,6 @@
     "description": "Timestamp of message creation (ISO-8601)",
     "required": true
   },
-  "thread_id": {
-    "value": null,
-    "type": "java.lang.String",
-    "description": "Unique identification string",
-    "required": false
-  },
   "note": {
     "value": null,
     "type": "java.lang.String",

--- a/src/org/centos/contra/pipeline/Utils.groovy
+++ b/src/org/centos/contra/pipeline/Utils.groovy
@@ -349,7 +349,7 @@ def sendMessage(String msgTopic, String msgProps, String msgContent, def provide
                 }
             }
         } catch(e) {
-            echo "FAIL: Could not send message to ${msg_provider}"
+            echo "FAIL: Could not send message to ${msg_provider} on topic ${msgTopic}"
             echo e.getMessage()
             sleep 30
             error e.getMessage()

--- a/vars/msgBusTestComplete.groovy
+++ b/vars/msgBusTestComplete.groovy
@@ -20,7 +20,6 @@ def call(Map parameters = [:]) {
         parameters['pipeline'] = parameters['pipeline'] ?: msgBusPipelineContent()()
         parameters['system'] = parameters['system'] ?: msgBusSystemContent()()
         parameters['generated_at'] = parameters['generated_at'] ?: java.time.Instant.now().toString()
-        parameters['thread_id'] = parameters['thread_id'] ?: UUID.randomUUID().toString()
 
         parameters = utils.mapMergeQuotes([parameters, runtimeArgs])
         try {

--- a/vars/msgBusTestError.groovy
+++ b/vars/msgBusTestError.groovy
@@ -19,7 +19,6 @@ def call(Map parameters = [:]) {
         parameters['artifact'] = parameters['artifact'] ?: msgBusArtifactContent()()
         parameters['generated_at'] = parameters['generated_at'] ?: java.time.Instant.now().toString()
         parameters['reason'] = parameters['reason'] ?: "Unknown execution error"
-        parameters['thread_id'] = parameters['thread_id'] ?: UUID.randomUUID().toString()
 
         parameters = utils.mapMergeQuotes([parameters, runtimeArgs])
         try {

--- a/vars/msgBusTestQueued.groovy
+++ b/vars/msgBusTestQueued.groovy
@@ -18,7 +18,6 @@ def call(Map parameters = [:]) {
         parameters['run'] = parameters['run'] ?: msgBusRunContent()()
         parameters['artifact'] = parameters['artifact'] ?: msgBusArtifactContent()()
         parameters['generated_at'] = parameters['generated_at'] ?: java.time.Instant.now().toString()
-        parameters['thread_id'] = parameters['thread_id'] ?: UUID.randomUUID().toString()
 
         parameters = utils.mapMergeQuotes([parameters, runtimeArgs])
         try {

--- a/vars/msgBusTestRunning.groovy
+++ b/vars/msgBusTestRunning.groovy
@@ -18,7 +18,6 @@ def call(Map parameters = [:]) {
         parameters['run'] = parameters['run'] ?: msgBusRunContent()()
         parameters['artifact'] = parameters['artifact'] ?: msgBusArtifactContent()()
         parameters['generated_at'] = parameters['generated_at'] ?: java.time.Instant.now().toString()
-        parameters['thread_id'] = parameters['thread_id'] ?: UUID.randomUUID().toString()
 
         parameters = utils.mapMergeQuotes([parameters, runtimeArgs])
         try {


### PR DESCRIPTION
- thread_id was removed from the spec in favor of pipeline.id

- I was asked to print out the topic when sendMessage fails to help with debugging when it happens

Signed-off-by: Johnny Bieren <jbieren@redhat.com>