### PR TITLE
make required enforcing again

### DIFF
--- a/src/org/centos/contra/pipeline/Utils.groovy
+++ b/src/org/centos/contra/pipeline/Utils.groovy
@@ -493,7 +493,7 @@ def validateBusKeyValue(def key, def value, Map defaults) {
 
     if (!defaults.containsKey(key)) {
         print "Invalid key for ${key}, ${value}"
-    } else if ((value == null) && (defaults[key]['required'])) {
+    } else if ((value == 'null') && (defaults[key]['required'])) {
         print "Required value missing for ${key}, ${value}"
     // if value's type != expected type from defaults
     } else if (!jenkinsIsAssignableFrom(value.getClass(), Class.forName(defaults[key]['type']))) {


### PR DESCRIPTION
I have no idea what changed, but it seems that the default null from the resource files comes in as string null now instead of normal groovy null

Signed-off-by: Johnny Bieren <jbieren@redhat.com>