### PR TITLE
ciPipeline: introduce body wrapper

### DIFF
--- a/vars/ciPipeline.groovy
+++ b/vars/ciPipeline.groovy
@@ -21,6 +21,7 @@
  *             after the build has run
  * timeoutValue: Integer - How long before the job should timeout. Defaults to 120 minutes.
  * sendMetrics: Boolean - send metrics to influx or not
+ * bodyWrapper: Closure - A closure that wraps the body. This can be used, for example, to alter the environment.
  * @param body
  * @return
  */
@@ -37,6 +38,7 @@ def call(Map parameters = [:], Closure body) {
     def postBuild = parameters.get('postBuild')
     def timeoutValue = parameters.get('timeout', 120)
     def sendMetrics = parameters.get('sendMetrics', true)
+    def bodyWrapper = parameters.get('bodyWrapper', { Closure bodyWrapperClosure -> bodyWrapperClosure() })
 
     def cimetrics = ciMetrics.metricsInstance
     cimetrics.prefix = buildPrefix
@@ -52,7 +54,9 @@ def call(Map parameters = [:], Closure body) {
                 preBuild()
             }
 
-            body()
+            bodyWrapper() {
+                body()
+            }
             topicSuffix = "complete"
         } catch (e) {
             // Set build result


### PR DESCRIPTION
Allow users of ciPipeline var to provide a closure that will
wrap the body of ciPipeline. It can be used to alter the entire
environment of the body.