### PR TITLE
Add failureFunction to ciPipeline()

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Parameters:
 - postBuild: A Closure that contains any post build steps. e.g. ArtifactArchiver step.
 - timeout: Set to time the pipeline out after timeout minutes. Defaults to 30.
 - sendMetrics: Whether to send metrics to influxdb. true or false.
+- failureFunction: A Closure that is executed only in the case of the main closure execution failing.
 ```groovy
 ciPipeline(buildPrefix: 'myrpmbuilder', decorateBuild: {currentBuild.displayName: 'env.BUILD_ID'})
 ```

--- a/vars/ciPipeline.groovy
+++ b/vars/ciPipeline.groovy
@@ -21,6 +21,7 @@
  *             after the build has run
  * timeoutValue: Integer - How long before the job should timeout. Defaults to 120 minutes.
  * sendMetrics: Boolean - send metrics to influx or not
+ * failureFunction: Closure - A closure that will be called only in the case that the execution of the main closure failed.
  * bodyWrapper: Closure - A closure that wraps the body. This can be used, for example, to alter the environment.
  * @param body
  * @return
@@ -38,6 +39,7 @@ def call(Map parameters = [:], Closure body) {
     def postBuild = parameters.get('postBuild')
     def timeoutValue = parameters.get('timeout', 120)
     def sendMetrics = parameters.get('sendMetrics', true)
+    def failureFunction = parameters.get('failureFunction')
     def bodyWrapper = parameters.get('bodyWrapper', { Closure bodyWrapperClosure -> bodyWrapperClosure() })
 
     def cimetrics = ciMetrics.metricsInstance
@@ -67,6 +69,10 @@ def call(Map parameters = [:], Closure body) {
 
             if (errorMsg) {
                 sendMessageWithAudit(errorMsg())
+            }
+
+            if (failureFunction) {
+                failureFunction()
             }
 
             throw e


### PR DESCRIPTION
The failureFunction parameter lets you pass in a closure of things that will run only if ciPipeline execution fails. This can be used for things such as sending emails on failures

Signed-off-by: Johnny Bieren <jbieren@redhat.com>