### PR TITLE
Define topicSuffix earlier in ciPipeline

### DIFF
--- a/vars/ciPipeline.groovy
+++ b/vars/ciPipeline.groovy
@@ -52,6 +52,7 @@ def call(Map parameters = [:], Closure body) {
     timeout(time: timeoutValue, unit: 'MINUTES') {
 
         try {
+            topicSuffix = "complete"
             if (preBuild) {
                 preBuild()
             }
@@ -59,7 +60,6 @@ def call(Map parameters = [:], Closure body) {
             bodyWrapper() {
                 body()
             }
-            topicSuffix = "complete"
         } catch (e) {
             // Set build result
             currentBuild.result = "FAILURE"


### PR DESCRIPTION
It seems that interactions with bodyWrapper can lead to topicSuffix never getting defined. Putting it before the body is ever called, first after the try, should make it so it is always defined.

Signed-off-by: Johnny Bieren <jbieren@redhat.com>