### PR TITLE
Throw exception of correct type

### DIFF
--- a/vars/executeInContainer.groovy
+++ b/vars/executeInContainer.groovy
@@ -46,7 +46,7 @@ def call(Map parameters) {
                 }
 
             } catch(err) {
-                throw "Error running ${containerScript}: ${err.toString()}"
+                error("Error running script '${containerScript}' in container ${containerName}: ${err.getMessage()}")
             } finally {
                 if (fileExists("logs/")) {
                     sh script: "mv logs ${stageDir}/logs", label: "Moving logs to the ${stageDir}/logs"


### PR DESCRIPTION
In `catch` block of `executeInContainer` fuction, exception of incorrect type is raised which causes
unhandled exception (with a stack trace) in Jenkins pipeline:
`java.lang.ClassCastException: class org.codehaus.groovy.runtime.GStringImpl cannot be cast to Throwable`

The fix is to throw exception using pipeline step `error`.