### PR TITLE
Allow custom headers in ciStage and ciPipeline

### DIFF
--- a/resources/README.md
+++ b/resources/README.md
@@ -41,6 +41,7 @@ env.pipelineId = UUID.randomUUID().toString() // Req for Pipeline Closure
 env.MSG_PROVIDER = "Message Bus" // Req for sendMessage function. Name of the messaging provider as set up in your Jenkins master config
 env.datagrepperUrl = "https://datagrepper.com" // Req for sendMessageWithAudit. The datagrepper instance for your messaging provider
 env.topicPrefix = "VirtualTopic.eng.ci" // The prefix to append pipeline.* to in order to form your final topic to send the message on
+env.msgProperties = "someheader=somevalue\nsomeheader2=somevalue2" // Optionally add keys to the message headers
 
 // Checkout contra-lib
 library identifier: "contra-lib@master",

--- a/vars/ciStage.groovy
+++ b/vars/ciStage.groovy
@@ -11,6 +11,7 @@
  * env.docsLink: A link to the docs describing the CI system
  * env.MSG_PROVIDER: This is actually required by the sendMessage function that ciStage uses. It is the provider configured in Jenkins on which to send messages
  * env.dataGrepperUrl: This is required by the sendMessageWithAudit function that ciStage uses. It tells the function where to look to confirm the message was sent as expected
+ * env.msgProperties: This optional variable can be defined to pass along custom message headers in the messages sent by ciStage
  *
  * Example Usage:
  *
@@ -43,7 +44,7 @@ def call(String stageName, Closure body) {
     runningMsg = msgBusStageMsg(contact: myContactArray(), pipeline: myPipelineArray())
     // send running message
     try {
-        sendMessageWithAudit(msgTopic: runningTopic, msgContent: runningMsg())
+        sendMessageWithAudit(msgTopic: runningTopic, msgProps: env.msgProperties ?: "", msgContent: runningMsg())
     } catch(e) {
         println("sendMessage failed with " + e)
     }
@@ -67,7 +68,7 @@ def call(String stageName, Closure body) {
     completeMsg = msgBusStageMsg(contact: myContactArray(), pipeline: myPipelineArray())
     // Send complete message
     try {
-        sendMessageWithAudit(msgTopic: completeTopic, msgContent: completeMsg())
+        sendMessageWithAudit(msgTopic: completeTopic, msgProps: env.msgProperties ?: "", msgContent: completeMsg())
     } catch(e) {
         println("sendMessage failed with " + e)
     }

--- a/vars/sendPipelineStatusMsg.groovy
+++ b/vars/sendPipelineStatusMsg.groovy
@@ -1,5 +1,6 @@
 /**
  * requires: env.topicPrefix
+ * optional: env.msgProperties: This optional variable can be defined to pass along custom message headers in the messages sent by sendPipelineStatusMsg
  * Example Usage:
  *
  * sendPipelineStatusMsg('complete') {
@@ -32,7 +33,7 @@ def call(String topicSuffix) {
         // Create message
         pipelineMsg = msgBusPipelineMsg(contact: myContactArray(), pipeline: myPipelineArray())
         // Send message
-        sendMessageWithAudit(msgTopic: msgTopic, msgContent: pipelineMsg())
+        sendMessageWithAudit(msgTopic: msgTopic, msgProps: env.msgProperties ?: "", msgContent: pipelineMsg())
 
     } catch(e) {
         println("No message was sent out on topic " + env.topicPrefix + ".pipeline." + topicSuffix + ". The error encountered was: " + e)


### PR DESCRIPTION
Add env.msgProperties functionality that allows adding custom message headers to ciStage and ciPipeline

Signed-off-by: Johnny Bieren <jbieren@redhat.com>