### PR TITLE
Clean kojiMessage error reporting

### DIFF
--- a/vars/kojiMessage.groovy
+++ b/vars/kojiMessage.groovy
@@ -11,10 +11,12 @@ def call(Map parameters = [:]) {
     def parsedMsg = readJSON text: message.replace("\n", "\\n")
 
     try {
-        parsedMsg['repo'] = utils.repoFromRequest(parsedMsg['request'][0])
-        def branch = utils.setBuildBranch(parsedMsg['request'][1])
-        parsedMsg['branch'] = branch[0]
-        parsedMsg['repo_branch'] = branch[1]
+        if (parsedMsg['request']) {
+            parsedMsg['repo'] = utils.repoFromRequest(parsedMsg['request'][0])
+            def branch = utils.setBuildBranch(parsedMsg['request'][1])
+            parsedMsg['branch'] = branch[0]
+            parsedMsg['repo_branch'] = branch[1]
+        }
     } catch (e) {
         if (ignoreErrors) {
             println("Ignoring error message: " + e)


### PR DESCRIPTION
Clean up the kojiMessage error reporting by only trying to use the 'request' key to set additional variables if it actually exists. A lot of people use this function now and don't need these variables, but the (irrelevant to what their purposes) error reported looks ugly in console logs

Signed-off-by: Johnny Bieren <jbieren@redhat.com>