### PR TITLE
Change full_name to full_names

### DIFF
--- a/resources/msgBusArtifactContent.json
+++ b/resources/msgBusArtifactContent.json
@@ -89,10 +89,10 @@
     "description": "A pull-spec that can be used to pull the image, for use with the container-image artifact only.",
     "required": false
   },
-  "full_name": {
-    "value": null,
-    "type": "java.lang.String",
-    "description": "Full name of the container image, in the form of 'registry:port/namespace/name:tag', for use with the redhat-container-image artifact only.",
+  "full_names": {
+    "value": [],
+    "type": "java.util.ArrayList",
+    "description": "Array of full names of the container image One full name is in the form of 'registry:port/namespace/name:tag', for use with the redhat-container-image artifact only.",
     "required": false
   },
   "registry_url": {

--- a/vars/msgBusArtifactContent.groovy
+++ b/vars/msgBusArtifactContent.groovy
@@ -56,7 +56,7 @@ def call(Map parameters = [:]) {
                 }
                 break
             case 'redhat-container-image':
-                if (!parameters.containsKey('id') || !parameters.containsKey('component') || !parameters.containsKey('full_name') || !parameters.containsKey('issuer') || !parameters.containsKey('nvr') || !parameters.containsKey('scratch')) {
+                if (!parameters.containsKey('id') || !parameters.containsKey('component') || !parameters.containsKey('full_names') || !parameters.containsKey('issuer') || !parameters.containsKey('nvr') || !parameters.containsKey('scratch')) {
                     throw new Exception("Error: Missing required fields for redhat-container-image artifact")
                 }
                 break


### PR DESCRIPTION
Later releases of https://pagure.io/fedora-ci/messages have a full_names list for the redhat-container-image instead of a full_name string

Signed-off-by: Johnny Bieren <jbieren@redhat.com>